### PR TITLE
Update negotiator.js

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -147,8 +147,9 @@ Negotiator._setupListeners = function(connection, pc, pc_id) {
   pc.oniceconnectionstatechange = function() {
     switch (pc.iceConnectionState) {
       case 'disconnected':
+        util.log('iceConnectionState is disconnected');
+        break;
       case 'failed':
-        util.log('iceConnectionState is disconnected, closing connections to ' + peerId);
         connection.close();
         break;
       case 'completed':


### PR DESCRIPTION
"disconnected": liveness check has failed for at least one component. This may be a transient state, e. g. on a flaky network, that can recover by itself.

it is not reasonable to desktop the connection when "disconnected state" is happened